### PR TITLE
Fix re-scaling range 0 to 254, analogs can now reach 255 when re-scaling is enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ add_executable(AnalogsEnhancer
 target_link_libraries(AnalogsEnhancer
   taihenForKernel_stub
   SceLibKernel_stub
-  sceIofilemgrForDriver_stub
+  SceIofilemgrForDriver_stub
   k
   gcc
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,6 @@ set_target_properties(AnalogsEnhancer
   PROPERTIES LINK_FLAGS "-nostdlib"
 )
 
-vita_create_self(AnalogsEnhancer.skprx AnalogsEnhancer
+vita_create_self(AnalogsEnhancerKai.skprx AnalogsEnhancer
   CONFIG ${CMAKE_SOURCE_DIR}/AnalogsEnhancer.yml
 )

--- a/README.md
+++ b/README.md
@@ -1,49 +1,68 @@
-This is a modified version just made for fun, by 2 noobs (t0mizwf26 & yakit4k0),<br>
-based on the original AnalogsEnhancer v1.1 (Commit 0629c4b) by Rinnegatamante.<br>
+## AnalogsEnhancerKai (アナログエンハンサー改) 
 
--- Compare with the original AnalogsEnhancer v1.1<br>
+> This is a modified version of [Rinnegatamante](https://github.com/Rinnegatamante)'s [AnalogsEnhancer](https://github.com/Rinnegatamante/AnalogsEnhancer) v1.1
+> 
+> Made by [t0mizwf26](https://github.com/t0mizwf26) & [yakit4k0](https://github.com/yakit4k0) (u/Yakitako-Kun)
+> 
+> Based on the original [AnalogsEnhancer](https://github.com/Rinnegatamante/AnalogsEnhancer) v1.1 code (commit [0629c4b](https://github.com/Rinnegatamante/AnalogsEnhancer/tree/0629c4b8ca124bc08cf6a6dc3e759a0eb8bbc45a)) by [Rinnegatamante](https://github.com/Rinnegatamante)
+> 
+> With the original "outer-deadzone" idea from u/lizin5ths (fork [Haasman0 / AnalogsEnhancer](https://github.com/Haasman0/AnalogsEnhancer))
 
-(1) Added outer-deadzone function for both re-scaling and non re-scaling deadzone mode.<br>
-(2) When using outer-deadzone with re-scaling, just like stick would stay centre/neutral within (inner-)deadzone, stick will become MAX when outer-deadzone is reached, and 360 degrees analog movement is still possible.<br>
-(3) When using outer-deadzone with NO re-scaling, when outer-deadzone is reached, stick becomes 8-way digital.<br>
-(When outer-deadzone is reached, x-axis or y-axis output will become MAX when actual x-axis or y-axis is also beyond "centre+/-49")<br>
+### New Features
+Compare with the original AnalogsEnhancer v1.1
+* Added outer-deadzone function for both re-scaling and non re-scaling deadzone mode.
+* When using outer-deadzone with re-scaling, just like stick would stay centre/neutral within (inner-)deadzone,<br>
+stick will become MAX when outer-deadzone is reached, and 360 degrees analog movement is still possible.
+* When using outer-deadzone with NO re-scaling, when outer-deadzone is reached, stick becomes 8-way digital.<br>
+(When outer-deadzone is reached, x-axis or y-axis output will become MAX when actual x-axis or y-axis is also beyond "centre+/-49")
 
-(4) Default config is now "left=0,127,n;right=0,127,n;n", so everything is disabled. No inner or outer deadzone, no re-scaling, no ANALOG_WIDE mode.<br>
-(5) Moved config file from ux0:/data/AnalogsEnhancer/config.txt to ur0:/tai/AnalogsEnhancerKai.txt (since it's now in ur0, edit with caution!)<br>
+### Changes
+* Default config when .txt config file missing is now "**left=0,127,n;right=0,127,n;n**", so everything is disabled.<br>
+Which means: no inner or outer deadzone, no re-scaling, no ANALOG_WIDE mode.
+* Moved config file from **ux0:data/AnalogsEnhancer/config.txt** to **ur0:tai/AnalogsEnhancerKai.txt** (since it's now in ur0, edit with caution!)
 
-(6) Bug fixed, now when using re-scaling, x / y can properly reach MAX right / down, which is 255, instead of just 254.<br>
-(7) Change CMakeLists.txt, using correct name "SceIofilemgrForDriver_stub" instead of "sceIofilemgrForDriver_stub", so the code can be compiled without error when using Linux (case-sensitive).<br>
+### Bug Fixes
+* When re-scaling = ON, x / y can now properly reach MAX=255 (without some other fixes which skip 254), instead of just 254 no 255.
+* Change CMakeLists.txt, using correct name "SceIofilemgrForDriver_stub" instead of "sceIofilemgrForDriver_stub", so the code can be compiled without error when using Linux (case-sensitive).
 
--- HOW TO USE:<br>
+### How to use
+* Put both AnalogsEnhancerKai.skprx and AnalogsEnhancerKai.txt in ur0:tai/
+* The AnalogsEnhancerKai.txt config included is "**left=32,127,y;right=32,127,y;n**", means 32 inner-DZ with re-scaling=ON for both L&R.
+* Edit **ur0:tai/config.txt**, disable other existing AnalogsEnhancer plugins, then add following:
+```
+# AnalogsEnhancerKai
+*KERNEL
+ur0:tai/AnalogsEnhancerKai.skprx
+```
+* Reboot PS Vita
+* N-nani? (Hopefully) NO MOA Kansei Dorifto?! Omae (Analog Stick Drift) wa Mou Shindeiru.
+* Edit the config file to fix even worse drift or explore other gimmicks.
 
-(1) Place AnalogsEnhancerKai.skprx in ur0:/tai/<br>
-(2) Install the plugin under *KERNEL in taiHen config file<br>
-*KERNEL<br>
-ur0:tai/AnalogsEnhancerKai.skprx<br>
-(3) Place AnalogsEnhancerKai.txt file in ur0:/tai/<br>
-(4) .txt config file contains config like:<br>
-left=0,127,n;right=0,127,n;n<br>
-(5) Above { 0 | 127 | n | 0 | 127 | n | n } in { left=0,127,n;right=0,127,n;n } means<br>
-{<br>
-| "left inner-deadzone (0-127)" | "left outer-deadzone (0-127)" | "left rescaling (y/n)" |<br>
-| "right inner-deadzone (0-127)" | "right outer-deadzone (0-127)" | "right rescaling (y/n)" |<br>
-| "use ANALOG_WIDE (y/n)" |<br>
-}<br>
+### More detail about config, deadzone, and 8-way
+* When editing the .txt config file<br>
+-1. It is recommended to use number between 0 - 127<br>
+-2. '0' means stick centre/neutral point, '127' means stick full tilt (gate)<br>
+( 0->127 == centre->gate, or in Homebrew App VitaTester's term: 127 towards 0 OR 255 )<br>
+-3. If inner-deadzone = 0, then inner-deadzone is OFF<br>
+-4. If outer-deadzone = 0 or 127, then outer-deadzone is OFF<br>
+-5. inner-DZ and outer-DZ will not overlap.<br>
+If overlapped in config (e.g. inner-DZ=70, outer-DZ=40), it will fix itself by making (outer-DZ = inner-DZ + 1)
 
--- NOTE:<br>
+* About outer-DZ in re-scaling=OFF mode
+I wish the following extremely poorly made & inaccurate picture would help to explain:<br>
+Assume both stick using the same setting, then this pic is representing config: "**left=25,100,n;right=25,100,n;n**"<br>
+Which means **inner-DZ=25, outer-DZ=100, re-scaling=OFF**<br>
+_**(The image shown are for illustration purposes only and not an exact representation of actual situation)**_<br>
+_(※画像はイメージです。(笑) image is image DESU)_<br>
+![DeadZone(25-100-n)](https://github.com/user-attachments/assets/8e5c732f-b37e-419e-a673-d8a29a70073e)<br>
+_(Errors in above pic: green area magnitude should be **25 to 99**, botom left SW direction should be "**0;255**")_<br>
+Using this example, <br>
+a) Want change green analog area to yellow/grey 8-way? "**left=24,25,n;right=24,25,n;n**"<br>
+b) Want change 8-way area into analog? "**left=25,127,n;right=25,127,n;n**"<br>
+c) Want no analog & 8-way fires at magnitude 50 instead of 100? "**left=49,50,n;right=49,50,n;n**"
 
-(0) 0 means stick centre/neutral point, 127 means stick fully tilt (MAX circle)<br>
-(1) inner-deadzone = 0 >> inner-deadzone disabled<br>
-(2) outer-deadzone = 0 or 127 >> outer-deadzone disabled<br>
-(3) inner and outer-deadzone will not overlap, if overlapped, it will fix itself, (outer = inner + 1)<br>
-In other words, it will always like:<br>
-{ MAX<--OuterDZ-->UsableRange<--InnerDZ-->Centre<--InnerDZ-->UsableRange<--OuterDZ-->MAX }<br>
-(4) For normal use to just fix small drift, "left={YourDeadzone},127,y;right={YourDeadzone},127,y;n" is recommended.<br>
-Personally I use "left=32,127,y;right=32,127,y;n" to fix my Vita Slim.<br>
-Or just use the original AnalogsEnhancer, much simpler than this Kai mess.<br>
-
--- THANKS:<br>
-Rinnegatamante, for the original deadzone plugin with re-scaling, Tokyo no longer drift tonight.<br>
-yakit4k0 (u/Yakitako-Kun), for compiling & helping to implement outer-deadzone into both rescaleAnalogs() and deadzoneAnalogs().<br>
-u/lizin5ths, for the idea of outer deadzone.<br>
-HENkaku community on Discord, for helping yakit4k0 to fix errors during compiling.
+### Thanks
+* Rinnegatamante, for the original plugin
+* yakit4k0, for compiling & helping to implement outer-deadzone into both rescaleAnalogs() and deadzoneAnalogs()
+* u/lizin5ths, for the idea of outer deadzone
+* HENkaku community, for helping to fix errors during compiling

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ based on the original AnalogsEnhancer v1.1 (Commit 0629c4b) by Rinnegatamante.<b
 (1) Place AnalogsEnhancerKai.skprx in ur0:/tai/<br>
 (2) Install the plugin under *KERNEL in taiHen config file<br>
 *KERNEL<br>
-ux0:tai/AnalogsEnhancerKai.skprx<br>
+ur0:tai/AnalogsEnhancerKai.skprx<br>
 (3) Place AnalogsEnhancerKai.txt file in ur0:/tai/<br>
 (4) .txt config file contains config like:<br>
 left=0,127,n;right=0,127,n;n<br>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+This is a modified version just made for fun, by 2 noobs (t0mizwf26 & yakit4k0),<br>
+based on the original AnalogsEnhancer v1.1 (Commit 0629c4b) by Rinnegatamante.<br>
+
+-- Compare with the original AnalogsEnhancer v1.1<br>
+
+(1) Added outer-deadzone function for both re-scaling and non re-scaling deadzone mode.<br>
+(2) When using outer-deadzone with re-scaling, just like stick would stay centre/neutral within (inner-)deadzone, stick will become MAX when outer-deadzone is reached, and 360 degrees analog movement is still possible.<br>
+(3) When using outer-deadzone with NO re-scaling, when outer-deadzone is reached, stick becomes 8-way digital.<br>
+(When outer-deadzone is reached, x-axis or y-axis output will become MAX when actual x-axis or y-axis is also beyond "centre+/-49")<br>
+
+(4) Default config is now "left=0,127,n;right=0,127,n;n", so everything is disabled. No inner or outer deadzone, no re-scaling, no ANALOG_WIDE mode.<br>
+(5) Moved config file from ux0:/data/AnalogsEnhancer/config.txt to ur0:/tai/AnalogsEnhancerKai.txt (since it's now in ur0, edit with caution!)<br>
+
+(6) Bug fixed, now when using re-scaling, x / y can properly reach MAX right / down, which is 255, instead of just 254.<br>
+(7) Change CMakeLists.txt, using correct name "SceIofilemgrForDriver_stub" instead of "sceIofilemgrForDriver_stub", so the code can be compiled without error when using Linux (case-sensitive).<br>
+
+-- HOW TO USE:<br>
+
+(1) Place AnalogsEnhancerKai.skprx in ur0:/tai/<br>
+(2) Install the plugin under *KERNEL in taiHen config file<br>
+*KERNEL<br>
+ux0:tai/AnalogsEnhancerKai.skprx<br>
+(3) Place AnalogsEnhancerKai.txt file in ur0:/tai/<br>
+(4) .txt config file contains config like:<br>
+left=0,127,n;right=0,127,n;n<br>
+(5) Above { 0 | 127 | n | 0 | 127 | n | n } in { left=0,127,n;right=0,127,n;n } means<br>
+{<br>
+| "left inner-deadzone (0-127)" | "left outer-deadzone (0-127)" | "left rescaling (y/n)" |<br>
+| "right inner-deadzone (0-127)" | "right outer-deadzone (0-127)" | "right rescaling (y/n)" |<br>
+| "use ANALOG_WIDE (y/n)" |<br>
+}<br>
+
+-- NOTE:<br>
+
+(0) 0 means stick centre/neutral point, 127 means stick fully tilt (MAX circle)<br>
+(1) inner-deadzone = 0 >> inner-deadzone disabled<br>
+(2) outer-deadzone = 0 or 127 >> outer-deadzone disabled<br>
+(3) inner and outer-deadzone will not overlap, if overlapped, it will fix itself, (outer = inner + 1)<br>
+In other words, it will always like:<br>
+{ MAX<--OuterDZ-->UsableRange<--InnerDZ-->Centre<--InnerDZ-->UsableRange<--OuterDZ-->MAX }<br>
+(4) For normal use to just fix small drift, "left={YourDeadzone},127,y;right={YourDeadzone},127,y;n" is recommended.<br>
+Personally I use "left=32,127,y;right=32,127,y;n" to fix my Vita Slim.<br>
+Or just use the original AnalogsEnhancer, much simpler than this Kai mess.<br>
+
+-- THANKS:<br>
+Rinnegatamante, for the original deadzone plugin with re-scaling, Tokyo no longer drift tonight.<br>
+yakit4k0 (u/Yakitako-Kun), for compiling & helping to implement outer-deadzone into both rescaleAnalogs() and deadzoneAnalogs().<br>
+u/lizin5ths, for the idea of outer deadzone.<br>
+HENkaku community on Discord, for helping yakit4k0 to fix errors during compiling.

--- a/main.c
+++ b/main.c
@@ -58,15 +58,27 @@ void rescaleAnalogs(uint8_t *x, uint8_t *y, int dead) {
         float clampingFactor = 1.0f;
         absAnalogX = fabs(analogX);
         absAnalogY = fabs(analogY);
-        if (absAnalogX > 127.0f || absAnalogY > 127.0f){
+
+        // use 128.0f instead of 127.0f, so the allowed range is (temporarily) -128 to 128 (i.e. -1 to 255) instead of -127 to 127 (i.e. 0 to 254)
+        if (absAnalogX > 128.0f || absAnalogY > 128.0f){
             if (absAnalogX > absAnalogY)
-                clampingFactor = 127.0f / absAnalogX;
+                clampingFactor = 128.0f / absAnalogX;
             else
-                clampingFactor = 127.0f / absAnalogY;
+                clampingFactor = 128.0f / absAnalogY;
         }
- 
-        *x = (uint8_t) ((clampingFactor * analogX) + 127.0f);
-        *y = (uint8_t) ((clampingFactor * analogY) + 127.0f);
+
+        analogX = (clampingFactor * analogX);
+        analogY = (clampingFactor * analogY);
+
+        // use clamping factor 0.992188f (= 127.0f / 128.0f) to fix -127 (i.e. < 0) issue introduced by above code, so the range is no longer -1 to 255 but 0 to 255
+        if (analogX < -127.0f || analogY < -127.0f){
+            analogX = 0.992188f * analogX;
+            analogY = 0.992188f * analogY;
+        }
+
+        // convert -127 ~ 128 back to 0 ~ 255 
+        *x = (uint8_t) (analogX + 127.0f);
+        *y = (uint8_t) (analogY + 127.0f);
     }else{
         *x = 127;
         *y = 127;

--- a/main.c
+++ b/main.c
@@ -70,7 +70,7 @@ void rescaleAnalogs(uint8_t *x, uint8_t *y, int dead) {
         analogX = (clampingFactor * analogX);
         analogY = (clampingFactor * analogY);
 
-        // use clamping factor 0.992188f (= 127.0f / 128.0f) to fix -127 (i.e. < 0) issue introduced by above code, so the range is no longer -1 to 255 but 0 to 255
+        // use clamping factor 0.992188f (= 127.0f / 128.0f) to fix '< -127' (i.e. '< 0') issue introduced by above code, so the range is no longer -1 to 255 but 0 to 255
         if (analogX < -127.0f || analogY < -127.0f){
             analogX = 0.992188f * analogX;
             analogY = 0.992188f * analogY;
@@ -112,10 +112,10 @@ void patchData(uint8_t *data) {
 void loadConfig(void) {
 
 	// Just in case the folder doesn't exist
-	ksceIoMkdir("ux0:data/AnalogsEnhancer", 0777); 
+	// ksceIoMkdir("ux0:data/AnalogsEnhancer", 0777); 
 	
 	// Loading generic config file
-	SceUID fd = ksceIoOpen("ux0:/data/AnalogsEnhancer/config.txt", SCE_O_RDONLY, 0777);
+	SceUID fd = ksceIoOpen("ur0:/tai/AnalogsEnhancerKai.txt", SCE_O_RDONLY, 0777);
 	if (fd >= 0){
 		ksceIoRead(fd, buffer, 32);
 		ksceIoClose(fd);

--- a/main.c
+++ b/main.c
@@ -21,18 +21,18 @@ static void (*patchFuncRight)(uint8_t *x, uint8_t *y, int dead, int deadOuter);
 
 // Courtesy of rsn8887
 void rescaleAnalogs(uint8_t *x, uint8_t *y, int dead, int deadOuter) {
-	//radial and scaled deadzone
-	//http://www.third-helix.com/2013/04/12/doing-thumbstick-dead-zones-right.html
-	//input and output values go from 0...255;
-	
-	if (dead == 0) return;
+    //radial and scaled deadzone
+    //http://www.third-helix.com/2013/04/12/doing-thumbstick-dead-zones-right.html
+    //input and output values go from 0...255;
+
+    if (dead == 0) return;
     if (dead > 126) {
         *x = 127;
         *y = 127;
         return;
     }
 
-	float analogX = (float) *x - 127.0f;
+    float analogX = (float) *x - 127.0f;
     float analogY = (float) *y - 127.0f;
     float deadZone = (float) dead;
     float magnitude = sqrt(analogX * analogX + analogY * analogY);
@@ -45,15 +45,15 @@ void rescaleAnalogs(uint8_t *x, uint8_t *y, int dead, int deadOuter) {
             maximum = sqrt(127.0f * 127.0f + ((127.0f * analogY) / absAnalogX) * ((127.0f * analogY) / absAnalogX));
         else
             maximum = sqrt(127.0f * 127.0f + ((127.0f * analogX) / absAnalogY) * ((127.0f * analogX) / absAnalogY));
- 
+
         if (maximum > 1.25f * 127.0f) maximum = 1.25f * 127.0f;
         if (maximum < magnitude) maximum = magnitude;
-       
+
         // find scaled axis values with magnitudes between zero and maximum
-        float scalingFactor = maximum / magnitude * (magnitude - deadZone) / (maximum - deadZone);     
+        float scalingFactor = maximum / magnitude * (magnitude - deadZone) / (maximum - deadZone);
         analogX = (analogX * scalingFactor);
         analogY = (analogY * scalingFactor);
- 
+
         // clamp to ensure results will always lie between 0 and 255
         float clampingFactor = 1.0f;
         absAnalogX = fabs(analogX);
@@ -76,7 +76,7 @@ void rescaleAnalogs(uint8_t *x, uint8_t *y, int dead, int deadOuter) {
             analogY = 0.992188f * analogY;
         }
 
-        // convert -127 ~ 128 back to 0 ~ 255 
+        // convert -127 ~ 128 back to 0 ~ 255
         *x = (uint8_t) (analogX + 127.0f);
         *y = (uint8_t) (analogY + 127.0f);
     }else{
@@ -89,7 +89,7 @@ void deadzoneAnalogs(uint8_t *x, uint8_t *y, int dead, int deadOuter) {
 
     // ensure inner deadzone and outer deadzone never overlap
     if (deadOuter <= dead) deadOuter = dead + 1;
-	// 0 or 128 will disable outer deadzone
+    // 0 or 128 will disable outer deadzone
     if (deadOuter == 0 || deadOuter > 128) deadOuter = 128;
 
     // both inner and outer deadzone disabled
@@ -120,7 +120,7 @@ void deadzoneAnalogs(uint8_t *x, uint8_t *y, int dead, int deadOuter) {
     if (magnitude >= deadOuter){
         if (*x > 176) *x = 255;
         else if (*x < 78) *x = 0;
-		else *x = 127;
+        else *x = 127;
         if (*y > 176) *y = 255;
         else if (*y < 78) *y = 0;
         else *y = 127;
@@ -129,75 +129,75 @@ void deadzoneAnalogs(uint8_t *x, uint8_t *y, int dead, int deadOuter) {
 }
 
 void patchData(uint8_t *data) {
-	patchFuncLeft(&data[12], &data[13], deadzoneLeft, deadzoneOuterLeft);
-	patchFuncRight(&data[14], &data[15], deadzoneRight, deadzoneOuterRight);
+    patchFuncLeft(&data[12], &data[13], deadzoneLeft, deadzoneOuterLeft);
+    patchFuncRight(&data[14], &data[15], deadzoneRight, deadzoneOuterRight);
 }
 
 void loadConfig(void) {
 
-	// Just in case the folder doesn't exist
-	// ksceIoMkdir("ux0:data/AnalogsEnhancer", 0777); 
-	
-	// Loading generic config file
-	SceUID fd = ksceIoOpen("ur0:/tai/AnalogsEnhancerKai.txt", SCE_O_RDONLY, 0777);
-	if (fd >= 0){
-		ksceIoRead(fd, buffer, 32);
-		ksceIoClose(fd);
-	}else sprintf(buffer, "left=0,128,n;right=0,128,n;y");
-	sscanf(buffer, "left=%lu,%lu,%c;right=%lu,%lu,%c;%c", &deadzoneLeft, &deadzoneOuterLeft, &rescaleLeft, &deadzoneRight, &deadzoneOuterRight, &rescaleRight, &widePatch);
-	
-	if (rescaleLeft == 'y') patchFuncLeft = rescaleAnalogs;
-	else patchFuncLeft = deadzoneAnalogs;
-	if (rescaleRight == 'y') patchFuncRight = rescaleAnalogs;
-	else patchFuncRight = deadzoneAnalogs;
-	if (widePatch == 'y') apply_wide_patch = 1;
-	
+    // Just in case the folder doesn't exist
+    // ksceIoMkdir("ux0:data/AnalogsEnhancer", 0777);
+
+    // Loading generic config file
+    SceUID fd = ksceIoOpen("ur0:/tai/AnalogsEnhancerKai.txt", SCE_O_RDONLY, 0777);
+    if (fd >= 0){
+        ksceIoRead(fd, buffer, 32);
+        ksceIoClose(fd);
+    }else sprintf(buffer, "left=0,128,n;right=0,128,n;y");
+    sscanf(buffer, "left=%lu,%lu,%c;right=%lu,%lu,%c;%c", &deadzoneLeft, &deadzoneOuterLeft, &rescaleLeft, &deadzoneRight, &deadzoneOuterRight, &rescaleRight, &widePatch);
+
+    if (rescaleLeft == 'y') patchFuncLeft = rescaleAnalogs;
+    else patchFuncLeft = deadzoneAnalogs;
+    if (rescaleRight == 'y') patchFuncRight = rescaleAnalogs;
+    else patchFuncRight = deadzoneAnalogs;
+    if (widePatch == 'y') apply_wide_patch = 1;
+
 }
 
 // Simplified generic hooking functions
 void hookFunctionExport(uint32_t nid, const void *func, const char *module) {
-	hooks[current_hook] = taiHookFunctionExportForKernel(KERNEL_PID, &refs[current_hook], module, TAI_ANY_LIBRARY, nid, func);
-	current_hook++;
+    hooks[current_hook] = taiHookFunctionExportForKernel(KERNEL_PID, &refs[current_hook], module, TAI_ANY_LIBRARY, nid, func);
+    current_hook++;
 }
 
 int ksceCtrlSetSamplingMode_patched(SceCtrlPadInputMode mode) {
-	if (mode == SCE_CTRL_MODE_ANALOG) mode = SCE_CTRL_MODE_ANALOG_WIDE;
-	return TAI_CONTINUE(int, refs[2], mode);
+    if (mode == SCE_CTRL_MODE_ANALOG) mode = SCE_CTRL_MODE_ANALOG_WIDE;
+    return TAI_CONTINUE(int, refs[2], mode);
 }
 
 int ksceCtrlPeekBufferPositive_patched(int port, SceCtrlData *ctrl, int count) {
-	int ret = TAI_CONTINUE(int, refs[0], port, ctrl, count);
-	patchData((uint8_t*)ctrl);
-	return ret;
+    int ret = TAI_CONTINUE(int, refs[0], port, ctrl, count);
+    patchData((uint8_t*)ctrl);
+    return ret;
 }
 
 int ksceCtrlReadBufferPositive_patched(int port, SceCtrlData *ctrl, int count) {
-	int ret = TAI_CONTINUE(int, refs[1], port, ctrl, count);
-	patchData((uint8_t*)ctrl);
-	return ret;
+    int ret = TAI_CONTINUE(int, refs[1], port, ctrl, count);
+    patchData((uint8_t*)ctrl);
+    return ret;
 }
 
 void _start() __attribute__ ((weak, alias ("module_start")));
 int module_start(SceSize argc, const void *args) {
-	
-	// Setup stuffs
-	loadConfig();
-	
-	// Hooking functions
-	hookFunctionExport(0xEA1D3A34, ksceCtrlPeekBufferPositive_patched, "SceCtrl");
-	hookFunctionExport(0x9B96A1AA, ksceCtrlReadBufferPositive_patched, "SceCtrl");
-	if (apply_wide_patch) hookFunctionExport(0x80F5E418, ksceCtrlSetSamplingMode_patched, "SceCtrl");
-	
-	return SCE_KERNEL_START_SUCCESS;
+
+    // Setup stuffs
+    loadConfig();
+
+    // Hooking functions
+    hookFunctionExport(0xEA1D3A34, ksceCtrlPeekBufferPositive_patched, "SceCtrl");
+    hookFunctionExport(0x9B96A1AA, ksceCtrlReadBufferPositive_patched, "SceCtrl");
+    if (apply_wide_patch) hookFunctionExport(0x80F5E418, ksceCtrlSetSamplingMode_patched, "SceCtrl");
+
+    return SCE_KERNEL_START_SUCCESS;
 }
 
 int module_stop(SceSize argc, const void *args) {
 
-	// Freeing hooks
-	while (current_hook-- > 0){
-		taiHookReleaseForKernel(hooks[current_hook], refs[current_hook]);
-	}
-		
-	return SCE_KERNEL_STOP_SUCCESS;
-	
+    // Freeing hooks
+    while (current_hook-- > 0){
+        taiHookReleaseForKernel(hooks[current_hook], refs[current_hook]);
+    }
+
+    return SCE_KERNEL_STOP_SUCCESS;
+
 }

--- a/main.c
+++ b/main.c
@@ -170,7 +170,7 @@ void loadConfig(void) {
         ksceIoRead(fd, buffer, 32);
         ksceIoClose(fd);
     // (Now if no config file present, everything disabled by default, including wide patch, stick works like normal)
-    }else sprintf(buffer, "left=0,128,n;right=0,127,n;n");
+    }else sprintf(buffer, "left=0,127,n;right=0,127,n;n");
     sscanf(buffer, "left=%lu,%lu,%c;right=%lu,%lu,%c;%c", &deadzoneLeft, &deadzoneOuterLeft, &rescaleLeft, &deadzoneRight, &deadzoneOuterRight, &rescaleRight, &widePatch);
 
     if (rescaleLeft == 'y') patchFuncLeft = rescaleAnalogs;


### PR DESCRIPTION
Fix the bug mentioned in issue https://github.com/Rinnegatamante/AnalogsEnhancer/issues/3 ,
Which when re-scaling is enabled, the analogs can only go from 0 to 254 instead of 0 to 255.
Instead of simply "if x or y = 254, then set x or y = 255", which makes 254 no longer available, this PR should properly fix the problem.